### PR TITLE
Add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,4 +11,5 @@
 /CONTRIBUTING.md    export-ignore
 /Makefile           export-ignore
 /tests              export-ignore
+/features           export-ignore
 /docs               export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Ignore all test and documentation for archive
+/.github            export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.scrutinizer.yml   export-ignore
+/.travis.yml        export-ignore
+/behat.yml          export-ignore
+/phpunit.xml.dist   export-ignore
+/phpcs.xml.dist     export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/CONTRIBUTING.md    export-ignore
+/Makefile           export-ignore
+/tests              export-ignore
+/docs               export-ignore


### PR DESCRIPTION
Add `.gitattributes` with `export-ignore` directive.
This allows to minimize the size of the future release tags.