### PR TITLE
Fix missing exception file and line info for debug rendering

### DIFF
--- a/src/App/Serialization/JsonRpcResponseErrorNormalizer.php
+++ b/src/App/Serialization/JsonRpcResponseErrorNormalizer.php
@@ -62,6 +62,8 @@ class JsonRpcResponseErrorNormalizer
             '_class' => get_class($error),
             '_code' => $error->getCode(),
             '_message' => $error->getMessage(),
+            '_file' => $error->getFile(),
+            '_line' => $error->getLine(),
         ];
 
         $trace = $this->filterErrorTrace($error->getTrace());

--- a/tests/Functional/App/Serialization/JsonRpcResponseErrorNormalizerTest.php
+++ b/tests/Functional/App/Serialization/JsonRpcResponseErrorNormalizerTest.php
@@ -60,6 +60,8 @@ class JsonRpcResponseErrorNormalizerTest extends TestCase
         $this->assertFalse(empty($debugData['_class']));
         $this->assertFalse(empty($debugData['_code']));
         $this->assertFalse(empty($debugData['_message']));
+        $this->assertFalse(empty($debugData['_file']));
+        $this->assertFalse(empty($debugData['_line']));
         $this->assertFalse(empty($debugData['_trace']));
 
         $this->assertSame(get_class($exception), $debugData['_class']);


### PR DESCRIPTION
Follow up #82

Fixes missing "file" and "line" info about exception on debug rendering.