### PR TITLE
Fix behat coverage not generated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "behat/behat": "^3.9.0",
+      "behat/behat": "^3.9.0,<=3.16.1",
     "coduo/php-matcher": "^6.0",
     "dvdoug/behat-code-coverage": "^5.0",
     "phpspec/prophecy": "^1.15",


### PR DESCRIPTION
Pin `behat/behat` below `3.16.1`
Starting at `v3.17.0`, no coverage file is generated due to XDebug driver badly managed:
```bash
No code coverage driver is available. No code coverage driver available
```