### PR TITLE
Improve behat coverage fix

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -14,6 +14,11 @@ build:
       - command: make build
         title: Build deps
         idle_timeout: 240
+      # Pin behat/behat below 3.16.1
+      # Starting at v3.17.0, no coverage file is generated due to XDebug driver badly managed
+      - title: PHP 8.2 - Fix XDebug driver badly managed by behat
+        command: composer update behat/behat -W --with "behat/behat:<3.17.0"
+        idle_timeout: 240
   tests:
     stop_on_failure: true
     override:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "behat/behat": "^3.9.0,<=3.16.1",
+    "behat/behat": "^3.9.0",
     "coduo/php-matcher": "^6.0",
     "dvdoug/behat-code-coverage": "^5.0",
     "phpspec/prophecy": "^1.15",


### PR DESCRIPTION
## 📑 Description
Starting at `v3.17.0`, no coverage file is generated due to XDebug driver badly managed by `behat/behat`:
```bash
No code coverage driver is available. No code coverage driver available
```
## ✅ Checks
<!-- 
WARNING: Be sure the following task are completed before moving the PR from "Draft" to "Ready for review"
-->
Before moving to "Ready for review" mode, the following must be completed:
- [ ] `Required` CI checks are all green

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
